### PR TITLE
Split two emails into two fields.

### DIFF
--- a/fuji_server/yaml/swagger.yaml
+++ b/fuji_server/yaml/swagger.yaml
@@ -5,7 +5,8 @@ info:
     Metrics</a>. <p> This work was supported by the <a href='https://www.fairsfair.eu/'>FAIRsFAIR</a>
     project (H2020-INFRAEOSC-2018-2020 Grant Agreement 831558).
   contact:
-    email: anusuriya.devaraju@googlemail.com ; rhuber@marum.de
+    email: anusuriya.devaraju@googlemail.com
+    x-additional-email: rhuber@marum.de
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT


### PR DESCRIPTION
The specification https://swagger.io/specification/#contact-object requires eMail to `MUST be in the format of an email address`. To preserve both authors, I split one off into a separate https://swagger.io/specification/#specification-extensions