### PR TITLE
Enable to disable authentication

### DIFF
--- a/fuji_server/__main__.py
+++ b/fuji_server/__main__.py
@@ -52,6 +52,7 @@ def main():
     metric_specification = config['SERVICE']['metric_specification']
 
     #TODO further implementation on authentication needed
+    auth_enabled = config.getboolean('USER', 'auth_enabled')
     usr = config['USER']['usr']
     pwd = config['USER']['pwd']
     authen.service_username = usr
@@ -80,7 +81,6 @@ def main():
     app = connexion.FlaskApp(__name__, specification_dir=YAML_DIR)
     API_YAML = os.path.join(ROOT_DIR, YAML_DIR, config['SERVICE']['swagger_yaml'])
     app.app.json_encoder = encoder.JSONEncoder
-    auth_enabled = False
     api_title = 'F-UJI : FAIRsFAIR Research Data Object Assessment Service'
     if auth_enabled:
         api_args = {
@@ -92,8 +92,7 @@ def main():
             'title': api_title
         }
 
-    app.add_api(API_YAML, arguments=api_args
-        , validate_responses=True)
+    app.add_api(API_YAML, arguments=api_args, validate_responses=True)
     app.app.wsgi_app = ProxyFix(app.app.wsgi_app)
     app.run(host=config['SERVICE']['service_host'], port=int(config['SERVICE']['service_port']))
 

--- a/fuji_server/config/server.ini
+++ b/fuji_server/config/server.ini
@@ -14,6 +14,7 @@ remote_log_host = fuji.localhost
 remote_log_path = /loghandler/index.php
 
 [USER]
+auth_enabled = true
 usr = username
 pwd = password
 

--- a/fuji_server/yaml/swagger.yaml
+++ b/fuji_server/yaml/swagger.yaml
@@ -704,6 +704,3 @@ components:
           explode: false
           schema:
             type: string
-
-security:
-- basicAuth: []


### PR DESCRIPTION
Hi again, I have played a bit with the F-UJI API and added some features to deploy and use it on our servers. You will probably receive a few pull requests to improve the deployment in the coming days :) 

I added a parameter to the config file that allow the user to disable authentication (anyone can start an evaluation without any login). 
Enabling authentication is still the default behavior if the user don't do anything to disable it

You can try it in live there (current temp URL for the API deployed on our servers): https://fuji-137-120-31-148.sslip.io/fuji/api/v1/ui/

We might be interested in implementing OAuth in the future (e.g. ORCID login), but no auth currently fits better our use of the API