### PR TITLE
Add CORS support and fix nginx reverse proxy fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 version: "3.3"
 services:
   fujirest:
-    image: "sneumann/fuji:latest"
+    image: "ghcr.io/pangaea-data-publisher/fuji:latest"
     ports:
       - "1071:1071"
+    environment:
+      - ENABLE_CORS=true
 
   notebook:
     image: "jupyter/minimal-notebook:latest"

--- a/fuji_server/__main__.py
+++ b/fuji_server/__main__.py
@@ -29,6 +29,7 @@ import os
 from logging.config import fileConfig
 import connexion
 from werkzeug.middleware.proxy_fix import ProxyFix
+from flask_cors import CORS
 
 from fuji_server import encoder
 from fuji_server.helper.preprocessor import Preprocessor
@@ -93,7 +94,9 @@ def main():
         }
 
     app.add_api(API_YAML, arguments=api_args, validate_responses=True)
-    app.app.wsgi_app = ProxyFix(app.app.wsgi_app)
+    app.app.wsgi_app = ProxyFix(app.app.wsgi_app, x_for=1, x_host=1)
+    if os.getenv('ENABLE_CORS', 'False').lower() == 'true':
+        CORS(app.app)
     app.run(host=config['SERVICE']['service_host'], port=int(config['SERVICE']['service_port']))
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ connexion~=2.7.0
 tika~=1.24
 configparser~=5.0.0
 werkzeug~=2.0
+flask-cors~=3.0.10
 rapidfuzz~=0.9.1
 setuptools~=45.2.0
 urlextract~=1.2.0


### PR DESCRIPTION
* Added the environment variable `ENABLE_CORS=true` to enable CORS request (to enable JavaScript client app to query the API from any URL), the default behavior stay the same (not enabled if environment variable not defined).
* Added forward headers to the `ProxyFix` to fix an issue with nginx reverse proxy (e.g. https://github.com/nginx-proxy/nginx-proxy).
* Updated the docker image in the `docker-compose.yml` to use the newly published image in the GitHub container registry and add the `ENABLE_CORS` environment variable

Thanks a lot!