### PR TITLE
Update metadata_mapper.py

### DIFF
--- a/fuji_server/helper/metadata_mapper.py
+++ b/fuji_server/helper/metadata_mapper.py
@@ -117,7 +117,7 @@ class Mapper(Enum):
         'object_type': [('citation_inbook_title','Book'),
                         ('citation_conference_title','ScholarlyArticle'),
                         ('citation_dissertation_institution', 'Thesis'),
-                        ('citation_dissertation_name', 'Thesis')
+                        ('citation_dissertation_name', 'Thesis'),
                         ('citation_journal_abbrev','ScholarlyArticle'),
                         ('citation_technical_report_institution','TechArticle'),
                         ('citation_technical_report_number','TechArticle'),


### PR DESCRIPTION
There was a comma missing after ('citation_dissertation_name', 'Thesis') in fuji_server.helper.metadata:mapper.py 