### PR TITLE
build: update build-backend to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,5 +99,5 @@ dev = ["yapf", "pytest", "pre-commit", "pytest-cov", "pylint", "sphinx-rtd-theme
 
 
 [build-system]
-requires = ["poetry>=1.2.0a2"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.5.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Hi,

your build is using poetry. The official poetry documentation recommends updating the build-backend to `poetry-core`.

Refs: https://python-poetry.org/docs/pyproject/#poetry-and-pep-517