### PR TITLE
chore: update pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,48 +1,48 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
     hooks:
-    - id: double-quote-string-fixer
-      types: [python]
-    - id: end-of-file-fixer
-    - id: fix-encoding-pragma
-    - id: mixed-line-ending
-      types: [python]
-    - id: trailing-whitespace
-      types: [python]
-    - id: check-yaml
-    - id: check-json
+      - id: double-quote-string-fixer
+        types: [python]
+      - id: end-of-file-fixer
+      - id: fix-encoding-pragma
+      - id: mixed-line-ending
+        types: [python]
+      - id: trailing-whitespace
+        types: [python]
+      - id: check-yaml
+      - id: check-json
 
-- repo: https://github.com/pre-commit/mirrors-yapf
-  rev: v0.31.0
-  hooks:
-  - id: yapf
-    name: yapf
-    types: [python]
-    exclude: &exclude_files >
-        (?x)^(
-            docs/.*|
-        )$
-    args: ['-i']
+  - repo: https://github.com/google/yapf
+    rev: v0.40.1
+    hooks:
+      - id: yapf
+        name: yapf
+        types: [python]
+        exclude: &exclude_files >
+          (?x)^(
+              docs/.*|
+          )$
+        args: ["-i"]
 
-# TODO: reenable and work through the massive list of errors and warnings
-# - repo: https://github.com/pycqa/pylint
-#   rev: pylint-2.8.0
-#   hooks:
-#   - id: pylint
-#     exclude: '^(docs/)|(examples/)|(fuji_server/models/)'
+  # TODO: reenable and work through the massive list of errors and warnings
+  # - repo: https://github.com/pycqa/pylint
+  #   rev: pylint-2.8.0
+  #   hooks:
+  #   - id: pylint
+  #     exclude: '^(docs/)|(examples/)|(fuji_server/models/)'
 
-- repo: local
-  hooks:
-  - id: version-number
-    name: Check version numbers
-    entry: python ./utils/validate_version_consistency.py
-    language: system
-    files: >-
-      (?x)^(
-        setup.py|
-        utils/validate_version_consistency.py|
-        masci_tools/__init__.py|
-        .bumpversion.cfg
-      )$
-    pass_filenames: false
+  - repo: local
+    hooks:
+      - id: version-number
+        name: Check version numbers
+        entry: python ./utils/validate_version_consistency.py
+        language: system
+        files: >-
+          (?x)^(
+            setup.py|
+            utils/validate_version_consistency.py|
+            masci_tools/__init__.py|
+            .bumpversion.cfg
+          )$
+        pass_filenames: false


### PR DESCRIPTION
Proposed changes:

- update the used pre-commit hooks in the config file to recent versions
- fix the indentation of the yaml file
- switch pre-commit/mirrors-yapf (DEPRECATED) to google/yapf

Refs: https://github.com/pre-commit/mirrors-yapf

Question: If you run `pre-commit run --all-files --color=always`, a lot of files get modified. Do you not enforce the style from the pre-commit-config so far?