### PR TITLE
ci: update ci run conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,20 @@
-name: fuji-server-main
+name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONUNBUFFERED: 1
+  FORCE_COLOR: 1 # colored output by pytest etc.
+
+permissions:
+  contents: read
 
 jobs:
 


### PR DESCRIPTION
Proposed changes:
- run CI only on master branch and pull requests
- dependabot creates branches, which would otherwise run CI twice
- newer commits on the same branch or PR cancel older CI runs