### PR TITLE
chore: drop python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.8', '3.7']
+        python-version: ['3.9', '3.8']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The service is **in development** and its assessment depends on several factors.
 ![alt text](https://github.com/pangaea-data-publisher/fuji/blob/master/fuji_server/static/main.png?raw=true)
 
 ## Requirements
-Python 3.7+
+Python 3.8+
 
 ### 308 redirects
 In order to deal with 308 redirects, the following patch has to be applied on urrlib:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers=[
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Information Analysis",
@@ -48,7 +47,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7.1"
+python = "^3.8.17"
 pyRdfa3 = "~3.5.3"
 requests = "~2.24.0"
 pyyaml = "~5.4"


### PR DESCRIPTION
I did not realize that [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html) was only available from Python >= 3.8.
Which makes my approach to fix the single version location in #344 not working for Python 3.7.

But since 3.7 reached [end of life](https://endoflife.date/python) this year and receives no more security patches, I suggest dropping the support.

What do you think? Most users would nowadays use a more recent Python version anyway.

Refs: #357