### PR TITLE
chore: remove obsolete six dependency

### DIFF
--- a/fuji_server/controllers/harvest_controller.py
+++ b/fuji_server/controllers/harvest_controller.py
@@ -1,6 +1,3 @@
-import connexion
-import six
-
 # -*- coding: utf-8 -*-
 ################################################################################
 # MIT License
@@ -43,7 +40,7 @@ def harvest_by_id(body=None):  # noqa: E501
 
     Harvest metadata of a data object based on its identifier # noqa: E501
 
-    :param body: 
+    :param body:
     :type body: dict | bytes
 
     :rtype: HarvestResults

--- a/fuji_server/encoder.py
+++ b/fuji_server/encoder.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from connexion.apps.flask_app import FlaskJSONEncoder
-import six
 
 from fuji_server.models.base_model_ import Model
 
@@ -11,7 +10,7 @@ class JSONEncoder(FlaskJSONEncoder):
     def default(self, o):
         if isinstance(o, Model):
             dikt = {}
-            for attr, _ in six.iteritems(o.swagger_types):
+            for attr, _ in o.swagger_types.items():
                 value = getattr(o, attr)
                 if value is None and not self.include_nulls:
                     continue

--- a/fuji_server/models/base_model_.py
+++ b/fuji_server/models/base_model_.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import pprint
 
-import six
 import typing
 
 from fuji_server import util
@@ -30,7 +29,7 @@ class Model(object):
         """
         result = {}
 
-        for attr, _ in six.iteritems(self.swagger_types):
+        for attr, _ in self.swagger_types.items():
             value = getattr(self, attr)
             if isinstance(value, list):
                 result[attr] = list(map(lambda x: x.to_dict() if hasattr(x, 'to_dict') else x, value))

--- a/fuji_server/util.py
+++ b/fuji_server/util.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
 
-import six
 import typing
 
 
@@ -16,7 +15,7 @@ def _deserialize(data, klass):
     if data is None:
         return None
 
-    if klass in six.integer_types or klass in (float, str, bool):
+    if klass in (int, float, str, bool):
         return _deserialize_primitive(data, klass)
     elif klass == object:
         return _deserialize_object(data)
@@ -50,7 +49,7 @@ def _deserialize_primitive(data, klass):
     try:
         value = klass(data)
     except UnicodeEncodeError:
-        value = six.u(data)
+        value = data
     except TypeError:
         value = data
     return value
@@ -109,7 +108,7 @@ def deserialize_model(data, klass):
     if not instance.swagger_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.swagger_types):
+    for attr, attr_type in instance.swagger_types.items():
         if data is not None \
                 and instance.attribute_map[attr] in data \
                 and isinstance(data, (list, dict)):
@@ -142,4 +141,4 @@ def _deserialize_dict(data, boxed_type):
     :return: deserialized dict.
     :rtype: dict
     """
-    return {k: _deserialize(v, boxed_type) for k, v in six.iteritems(data)}
+    return {k: _deserialize(v, boxed_type) for k, v in data.items()}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
   "rapidfuzz~=3.1.2",
   "rdflib~=6.1.1",
   "requests~=2.24.0",
-  "six~=1.16.0",
   "sparqlwrapper~=1.8.5",
   "tika~=1.24",
   "tldextract~=3.1.2",


### PR DESCRIPTION
The "six" dependency is not needed, because this project does only support Python >= 3.8. So no compatibility layers with Python 2 are needed.