### PR TITLE
fix: remove faulty function parameter

### DIFF
--- a/fuji_server/helper/preprocessor.py
+++ b/fuji_server/helper/preprocessor.py
@@ -585,7 +585,7 @@ class Preprocessor(object):
     @classmethod
     def get_licenses(cls):
         if not cls.all_licenses:
-            cls.retrieve_licenses(cls.SPDX_URL, True)
+            cls.retrieve_licenses(True)
         # return cls.all_licenses, cls.license_names, cls.license_urls
         return cls.all_licenses, cls.license_names
 


### PR DESCRIPTION
There was a bug in the get_licenses() method of the preprocessor.
Can line 589 be removed?

Refs: #388