### PR TITLE
chore: remove obsolete autosemver dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Information Analysis"
 ]
 dependencies = [
-  "autosemver~=0.5.5",
   "beautifulsoup4~=4.8.2",
   "configparser~=5.0.2",
   "connexion[swagger-ui]~=2.9.0",


### PR DESCRIPTION
The autosemver dependency is not used in any workflow. Is that correct? Can it be removed to clean up the dependencies?