### PR TITLE
chore: add hatch envs and scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: 1
   FORCE_COLOR: 1 # colored output by pytest etc.
+  CLICOLOR_FORCE: 1 # colored output by ruff
 
 permissions:
   contents: read
@@ -68,9 +69,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
-    - run: pip install pre-commit
-    - name: Run pre-commit
-      run: pre-commit run --all-files --color=always
+    - run: pip install --upgrade pip
+    - run: pip install hatch
+    - run: hatch run lint
 
   tests:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,14 +68,17 @@ version = "3.0.0"
 
 [project.optional-dependencies]
 dev = [
-  "fuji[testing]",
-  "pre-commit"
+  "fuji[lint]",
+  "fuji[testing]"
 ]
 docs = [
   "docutils>=0.14,<0.18",
   "myst-parser~=0.16",
   "sphinx~=4.2",
   "sphinx-rtd-theme~=1.0"
+]
+lint = [
+  "pre-commit~=3.3"
 ]
 report = [
   "bokeh~=2.4",
@@ -102,6 +105,20 @@ include = [
   "LICENSE",
   "README.md"
 ]
+
+[tool.hatch.envs.default]
+dev-mode = true
+features = [
+  "lint",
+  "testing"
+]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args}"
+cov = "pytest --cov {args}"
+cov-xml = "pytest --cov --cov-report=xml {args}"
+cov-html = "pytest --cov --cov-report=html {args}"
+lint = "pre-commit run --all-files --color=always {args}"
 
 [tool.hatch.build.targets.wheel]
 packages = ["fuji_server"]


### PR DESCRIPTION
I added a default hatch environment that can be accessed with:
```
hatch shell
```
Also I added a few script entries (formerly these were shell scripts), that can be run with:
```
hatch run test
```
or
```
hatch run lint
```