### PR TITLE
chore: update ci jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,38 +19,33 @@ permissions:
 
 jobs:
 
-  docs:
+  # TODO: disable docs build until decision is made
 
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-
-    - name: Cache python dependencies
-      id: cache-pip
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: pip-docs-${{ hashFiles('pyproject.toml') }}
-        restore-keys: |
-          pip-docs-
-
-    - name: Install python dependencies
-      run: |
-        pip install .[docs]
-        pip show fuji
-
-    - name: Build documentation
-      env:
-        READTHEDOCS: 'True'
-      run: |
-        # TODO: add W flag back after fixing warnings
-        SPHINXOPTS='-n' make -C docs html
+  # docs:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Set up Python 3.11
+  #     uses: actions/setup-python@v4
+  #     with:
+  #       python-version: '3.11'
+  #   - name: Cache python dependencies
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/.cache/pip
+  #       key: pip-docs-${{ hashFiles('pyproject.toml') }}
+  #       restore-keys: |
+  #         pip-docs-
+  #   - name: Install python dependencies
+  #     run: |
+  #       python -m pip install .[docs]
+  #       python -m pip show fuji
+  #   - name: Build documentation
+  #     env:
+  #       READTHEDOCS: 'True'
+  #     run: |
+  #       # TODO: add W flag back after fixing warnings
+  #       SPHINXOPTS='-n' make -C docs html
 
   lint:
     runs-on: ubuntu-22.04
@@ -62,48 +57,39 @@ jobs:
         path: |
           ~/.cache/pip
           ~/.cache/pre-commit
-        key: pip-pre-commit-${{ hashFiles('.pre-commit-config.yaml', 'pyproject.toml') }}
+        key: pip-lint-${{ hashFiles('.pre-commit-config.yaml', 'pyproject.toml') }}
         restore-keys: |
-          pip-pre-commit-
-    - name: Set up Python 3.8
+          pip-lint-
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
-    - run: pip install --upgrade pip
-    - run: pip install hatch
+        python-version: '3.11'
+    - run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install hatch
     - run: hatch run lint
 
   tests:
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.8']
-
+        python-version: ['3.11', '3.8']
     steps:
     - uses: actions/checkout@v3
-
     - name: Cache python dependencies
-      id: cache-pip
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('pyproject.toml') }}
+        key: pip-tests-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-          pip-${{ matrix.python-version }}-tests
-
+          pip-tests-${{ matrix.python-version }}-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-
     - name: Install python dependencies
       run: |
-        pip install .[testing]
-        pip freeze
-        pip show fuji
-
-    - name: Run pytest
-      run: pytest --cov
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install hatch
+    - name: Run test suite with coverage
+      run: hatch run cov


### PR DESCRIPTION
## Description

This PR proposes the following changes:
- replace pip with python -m pip, more explicit
- rename ci caches
- use ubuntu 22.04 for all ci jobs
- add python 3.11 to tests
- run tests with hatch

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.