### PR TITLE
docs: remove unnecessary line in contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,6 @@ Here's how to set up F-UJI for local development.
     ```console
     $ cd fuji
     $ hatch shell
-    $ pip install ".[dev]"
     $ pre-commit install
     ```
 4. Create a branch for local development:


### PR DESCRIPTION
## Description

This PR removes an unnecessary line in the dev setup description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
