### PR TITLE
docs: add links to issue tracker in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,11 @@ If you are reporting a bug, please include:
 
 ### Fix Bugs
 
-Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
-wanted" is open to whoever wants to implement it.
+Look through the GitHub issues for bugs. Anything tagged with [bug][bug-issues] and [help wanted][help-wanted-issues] is open to whoever wants to implement it.
 
 ### Implement Features
 
-Look through the GitHub issues for features. Anything tagged with "enhancement"
-and "help wanted" is open to whoever wants to implement it.
+Look through the GitHub issues for features. Anything tagged with [enhancement][feature-issues] and [help wanted][help-wanted-issues] is open to whoever wants to implement it.
 
 ### Write Documentation
 
@@ -119,3 +117,8 @@ $ hatch run test -m smoke
 ---
 
 *This contributor guide is adapted from [cookiecutter-pypackage (BSD 3-Clause License)](https://github.com/audreyfeldroy/cookiecutter-pypackage/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/CONTRIBUTING.rst).*
+
+<!-- Markdown links -->
+[bug-issues]: https://github.com/pangaea-data-publisher/fuji/issues?q=is%3Aopen+is%3Aissue+label%3Abug
+[feature-issues]: https://github.com/pangaea-data-publisher/fuji/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement
+[help-wanted-issues]: https://github.com/pangaea-data-publisher/fuji/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22


### PR DESCRIPTION
## Description

This PR adds links from the contributor guide directly to the issue tracker's labels.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
