### PR TITLE
chore: replace ambiguous import requests as re

### DIFF
--- a/fuji_server/helper/catalogue_helper_datacite.py
+++ b/fuji_server/helper/catalogue_helper_datacite.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-import requests as re
+import requests
 
 from fuji_server.helper.catalogue_helper import MetaDataCatalogue
 
@@ -46,7 +46,7 @@ class MetaDataCatalogueDataCite(MetaDataCatalogue):
         """
         response = None
         try:
-            res = apiresponse = re.get(self.apiURI + '/' + pid, timeout=5)
+            res = requests.get(self.apiURI + '/' + pid, timeout=5)
             self.logger.info('FsF-F4-01M : Querying DataCite API for -:' + str(pid))
             if res.status_code == 200:
                 self.islisted = True

--- a/fuji_server/helper/catalogue_helper_mendeley_data.py
+++ b/fuji_server/helper/catalogue_helper_mendeley_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-import requests as re
+import requests
 
 from fuji_server.helper.catalogue_helper import MetaDataCatalogue
 
@@ -42,7 +42,7 @@ class MetaDataCatalogueMendeleyData(MetaDataCatalogue):
         for pid in pidlist:
             try:
                 if pid:
-                    res = apiresponse = re.get(self.apiURI + '/' + re.utils.quote(str(pid)), timeout=1)
+                    res = requests.get(self.apiURI + '/' + requests.utils.quote(str(pid)), timeout=1)
                     self.logger.info('FsF-F4-01M : Querying Mendeley Data API for -:' + str(pid))
                     if res.status_code == 200:
                         resp = res.json()


### PR DESCRIPTION
## Description

Using `import requests as re` is a bad idea. `re` is the name of the regular expressions package from the python standard library. So in case, you ever want to use regular expressions in those modules, you get a name clash. Please use requests instead.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.