### PR TITLE
fix: make re-strings raw strings to fix DeprecationWarnings

### DIFF
--- a/fuji_server/harvester/metadata_harvester.py
+++ b/fuji_server/harvester/metadata_harvester.py
@@ -476,13 +476,13 @@ class MetadataHarvester():
             for link_prop in parsed_link[1:]:
                 link_prop = str(link_prop).strip()
                 if link_prop.startswith('anchor'):
-                    anchor_match = re.search('anchor\s*=\s*\"?([^,;"]+)\"?', link_prop)
+                    anchor_match = re.search(r'anchor\s*=\s*\"?([^,;"]+)\"?', link_prop)
                 if link_prop.startswith('rel'):
-                    rel_match = re.search('rel\s*=\s*\"?([^,;"]+)\"?', link_prop)
+                    rel_match = re.search(r'rel\s*=\s*\"?([^,;"]+)\"?', link_prop)
                 elif link_prop.startswith('type'):
-                    type_match = re.search('type\s*=\s*\"?([^,;"]+)\"?', link_prop)
+                    type_match = re.search(r'type\s*=\s*\"?([^,;"]+)\"?', link_prop)
                 elif link_prop.startswith('formats'):
-                    formats_match = re.search('formats\s*=\s*\"?([^,;"]+)\"?', link_prop)
+                    formats_match = re.search(r'formats\s*=\s*\"?([^,;"]+)\"?', link_prop)
             if type_match:
                 found_type = type_match[1]
             if rel_match:

--- a/fuji_server/helper/identifier_helper.py
+++ b/fuji_server/helper/identifier_helper.py
@@ -121,7 +121,7 @@ class IdentifierHelper:
                 #workaround to identify arks properly:
                 self.identifier = self.identifier.replace('/ark:' , '/ark:/' )
                 self.identifier = self.identifier.replace('/ark://', '/ark:/')
-                generic_identifiers_org_pattern = '^([a-z0-9\._]+):(.+)'
+                generic_identifiers_org_pattern = r'^([a-z0-9\._]+):(.+)'
 
                 if self.is_uuid():
                     self.identifier_schemes = ['uuid']

--- a/fuji_server/helper/metadata_collector_xml.py
+++ b/fuji_server/helper/metadata_collector_xml.py
@@ -314,7 +314,7 @@ class MetaDataCollectorXML(MetaDataCollector):
                         res[prop] = propcontent[0].get('tree').text
                     else:
                         res[prop] = lxml.etree.tostring(propcontent[0].get('tree'), method='text', encoding='unicode')
-                        res[prop] = re.sub('\s+', ' ', res[prop])
+                        res[prop] = re.sub(r'\s+', ' ', res[prop])
                         res[prop] = res[prop].strip()
                 else:
                     for propelem in propcontent:
@@ -324,7 +324,7 @@ class MetaDataCollectorXML(MetaDataCollector):
                             res[prop].append(propelem.get('tree').text)
                         else:
                             resprop = lxml.etree.tostring(propelem.get('tree'), method='text', encoding='unicode')
-                            resprop = re.sub('\s+', ' ', resprop)
+                            resprop = re.sub(r'\s+', ' ', resprop)
                             resprop = resprop.strip()
                             res[prop].append(resprop)
 


### PR DESCRIPTION
## Description

During the tests Python throws several `DeprecationWarning`s, because of `invalid escape sequence`s.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
