### PR TITLE
chore: add file-contents-sorter pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
   rev: v4.4.0
   hooks:
   - id: end-of-file-fixer
-    exclude_types: [json, text]
   - id: mixed-line-ending
     types: [python]
   - id: trailing-whitespace
@@ -12,6 +11,8 @@ repos:
   - id: check-json
   - id: pretty-format-json
     args: [--autofix]
+  - id: file-contents-sorter
+    files: ^fuji_server\/data\/.*.txt$
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.10.0
   hooks:


### PR DESCRIPTION
## Description

This PR proposes adding a pre-commit hook, that automatically sorts the contents or *.txt files in data/.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
