### PR TITLE
fix: flask limiter error

### DIFF
--- a/fuji_server/__main__.py
+++ b/fuji_server/__main__.py
@@ -78,7 +78,7 @@ def main():
     logger.info("Total default namespaces specified : {}".format(len(preproc.getDefaultNamespaces())))
 
     app = create_fuji_app(config)
-    limiter = Limiter(app.app, key_func=get_remote_address, default_limits=[str(config["SERVICE"]["rate_limit"])])
+    limiter = Limiter(get_remote_address, app=app.app, default_limits=[str(config["SERVICE"]["rate_limit"])])
     # comment in case waitress is wished
     # app.run(host=config['SERVICE']['service_host'], port=int(config['SERVICE']['service_port']),debug=False)
     # switch to waitress


### PR DESCRIPTION
## Description

The new version of flask-limiter changed its API and wanted requires only arguments, except key_func.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- This pull request template is adapted from:
<!--- "open-source-templates", https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- "amazing-github-template", https://github.com/dec0dOS/amazing-github-template (MIT License). --->
