### PR TITLE
refactor: move application factory

### DIFF
--- a/fuji_server/__main__.py
+++ b/fuji_server/__main__.py
@@ -34,7 +34,7 @@ from flask_limiter.util import get_remote_address
 from waitress import serve
 
 import fuji_server.controllers.authorization_controller as authen
-from fuji_server.app.fuji_app import create_fuji_app
+from fuji_server.app import create_app
 from fuji_server.helper.preprocessor import Preprocessor
 
 

--- a/fuji_server/app.py
+++ b/fuji_server/app.py
@@ -32,16 +32,16 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from fuji_server import encoder
 
 
-def create_fuji_app(config):
+def create_app(config):
     """
     Function which initializes the FUJI connexion flask app and returns it
     """
     # you can also use Tornado or gevent as the HTTP server, to do so set server to tornado or gevent
-    ROOT_DIR = main_dir = Path(__file__).parent.parent
+    ROOT_DIR = Path(__file__).parent
     YAML_DIR = config["SERVICE"]["yaml_directory"]
 
     app = connexion.FlaskApp(__name__, specification_dir=YAML_DIR)
-    API_YAML = os.path.join(ROOT_DIR, YAML_DIR, config["SERVICE"]["swagger_yaml"])
+    API_YAML = ROOT_DIR.joinpath(YAML_DIR, config["SERVICE"]["swagger_yaml"])
     app.app.json_encoder = encoder.JSONEncoder
 
     app.add_api(API_YAML, validate_responses=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from unittest import mock
 
 import pytest
 
-from fuji_server.app.fuji_app import create_fuji_app
+from fuji_server.app import create_app
 from fuji_server.helper.preprocessor import Preprocessor
 
 if TYPE_CHECKING:
@@ -105,7 +105,7 @@ def temporary_preprocessor(temporary_data_directory) -> Preprocessor:
 
 @pytest.fixture(scope="session")
 def app(test_config) -> Flask:
-    _app = create_fuji_app(test_config)
+    _app = create_app(test_config)
     _app.testing = True
     return _app.app
 


### PR DESCRIPTION
## Description

The application factory is commonly named create_app. Also there is no need to keep the application factory in its own package, if there is only one module present.

Related issue: #390

## Types of changes
- [x] Refactoring (no functional changes, no api changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
