### PR TITLE
ci: publish pytest results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,34 +82,31 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --upgrade hatch
-
     - name: Run test suite with coverage
       run: hatch run cov-ci
-
-    - name: Upload coverage reports
+    - name: Generate badges
+      if: always()
+      run: hatch run badges
+    - name: Upload test results
+      if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: coverage
+        name: test-results
         retention-days: 1
-        path: |
-          junit.xml
-          pytest-coverage.txt
+        path: pytest-junit.xml
+    - name: Upload coverage results
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-results
+        retention-days: 1
+        path: pytest-cobertura.xml
 
-  coverage:
+  event_file:
     runs-on: ubuntu-22.04
-    needs: tests
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
-    - name: Download coverage reports
-      uses: actions/download-artifact@v3
+    - uses: actions/upload-artifact@v3
       with:
-        name: coverage
-    # Ref: https://github.com/MishaKav/pytest-coverage-comment
-    - name: Add coverage comment
-      uses: MishaKav/pytest-coverage-comment@v1.1.48
-      with:
-        title: Coverage
-        pytest-coverage-path: pytest-coverage.txt
-        junitxml-path: junit.xml
+        name: event-file
+        retention-days: 1
+        path: ${{ github.event_path }}

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,0 +1,76 @@
+name: Reports
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types:
+    - completed
+permissions: {}
+
+jobs:
+  # Ref: https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches
+  test-results:
+    runs-on: ubuntu-22.04
+    if: github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      checks: write
+      # required to create pull request comments
+      pull-requests: write
+      # required by download step to access artifacts API
+      actions: read
+    steps:
+    - name: Download and Extract Artifacts
+      uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2.28.0
+      with:
+        run_id: ${{ github.event.workflow_run.id }}
+        path: artifacts
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@d93dbc08d265e4653da0c0af544bee2a851d3e38 # v2.10.0
+      with:
+        comment_title: ':clipboard: Pytest Results'
+        commit: ${{ github.event.workflow_run.head_sha }}
+        event_file: artifacts/event-file/event.json
+        event_name: ${{ github.event.workflow_run.event }}
+        files: artifacts/test-results/pytest-junit.xml
+
+  coverage-results:
+    runs-on: ubuntu-22.04
+    if: github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      # required to create pull request comments
+      pull-requests: write
+      # required by download step to access artifacts API
+      actions: read
+    steps:
+    - name: Download and Extract Artifacts
+      uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2.28.0
+      with:
+        run_id: ${{ github.event.workflow_run.id }}
+        path: artifacts
+    # Ref: https://github.com/irongut/CodeCoverageSummary#usage
+    - name: Generate Code Coverage Report
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
+      with:
+        filename: artifacts/coverage-results/pytest-cobertura.xml
+        badge: true
+        format: markdown
+        hide_complexity: true
+        output: both
+    - name: Write to Job Summary
+      run: |
+        echo "## :clipboard: Code Coverage" >> $GITHUB_STEP_SUMMARY
+        cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+    - name: Get Pull Request number
+      run: |
+        echo "number=$(jq .pull_request.number artifacts/event-file/event.json)" >> $GITHUB_OUTPUT
+      id: get-pr-number
+    # Ref: https://github.com/marocchino/sticky-pull-request-comment#inputs
+    - name: Add Code Coverage PR Comment
+      if: ${{ steps.get-pr-number.outputs.number }} != null
+      uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd # v2.8.0
+      with:
+        recreate: true
+        number: ${{ steps.get-pr-number.outputs.number }}
+        path: code-coverage-results.md
+
+    # TODO: Coverage badge

--- a/.gitignore
+++ b/.gitignore
@@ -76,8 +76,8 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
-junit.xml
-pytest-coverage.txt
+pytest-cobertura.xml
+pytest-junit.xml
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ report = [
   "jupyter~=1.0"
 ]
 testing = [
+  "genbadge[tests]~=1.1",
   "pytest~=7.4",
   "pytest-cov~=4.1",
   "pytest-randomly~=3.15",
@@ -126,10 +127,10 @@ features = [
 ]
 
 [tool.hatch.envs.default.scripts]
+badges = "genbadge tests --input-file=pytest-junit.xml"
 cov = "pytest --cov {args}"
-cov-ci = "pytest --cov --junitxml=junit.xml | tee pytest-coverage.txt"
+cov-ci = "pytest --cov --junitxml=pytest-junit.xml --cov-report=xml:pytest-cobertura.xml {args}"
 cov-html = "pytest --cov --cov-report=html {args}"
-cov-xml = "pytest --cov --cov-report=xml {args}"
 lint = "pre-commit run --all-files --color=always {args}"
 test = "pytest {args}"
 


### PR DESCRIPTION
## Description

This is a new attempt to publish test and coverage reports.

This workflow is proposed in https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches.

The Pytest run will generate a junit XML file containing the test results. This file will be uploaded as an artifact. After the CI workflow is finished, another workflow ("Reports") will start and download the test results, generate a job summary and it also be able to comment on PRs.

After that a similar approach is taken to publish code coverage as well.

Related issue: #429 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.