### PR TITLE
ci: add rule to disable docker build in forks

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -23,6 +23,9 @@ jobs:
     # Build and push image to GitHub Container Registry https://docs.docker.com/docker-hub/builds/
     runs-on: ubuntu-22.04
 
+    # do not run in forks
+    if: github.repository == 'pangaea-data-publisher/fuji'
+
     steps:
 
     - run: docker --version


### PR DESCRIPTION
## Description

This PR disables the Docker build in forked repositories. Also the job failed every time in the push step.

## Types of changes
- [x] Build related changes

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- This pull request template is adapted from:
<!--- "open-source-templates", https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- "amazing-github-template", https://github.com/dec0dOS/amazing-github-template (MIT License). --->
