### PR TITLE
fix: rename application factory

### DIFF
--- a/fuji_server/__main__.py
+++ b/fuji_server/__main__.py
@@ -31,7 +31,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from waitress import serve
 
-from fuji_server.app.fuji_app import create_fuji_app
+from fuji_server.app.fuji_app import create_app
 from fuji_server.helper.preprocessor import Preprocessor
 
 
@@ -74,7 +74,7 @@ def main():
     logger.info(f"Total LD vocabs imported : {len(preproc.getLinkedVocabs())}")
     logger.info(f"Total default namespaces specified : {len(preproc.getDefaultNamespaces())}")
 
-    app = create_fuji_app(config)
+    app = create_app(config)
     Limiter(get_remote_address, app=app.app, default_limits=[str(config["SERVICE"]["rate_limit"])])
     # comment in case waitress is wished
     # app.run(host=config['SERVICE']['service_host'], port=int(config['SERVICE']['service_port']),debug=False)

--- a/fuji_server/app.py
+++ b/fuji_server/app.py
@@ -30,16 +30,16 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from fuji_server import encoder
 
 
-def create_fuji_app(config):
+def create_app(config):
     """
     Function which initializes the FUJI connexion flask app and returns it
     """
     # you can also use Tornado or gevent as the HTTP server, to do so set server to tornado or gevent
-    ROOT_DIR = Path(__file__).parent.parent
+    ROOT_DIR = Path(__file__).parent
     YAML_DIR = config["SERVICE"]["yaml_directory"]
 
     app = connexion.FlaskApp(__name__, specification_dir=YAML_DIR)
-    API_YAML = os.path.join(ROOT_DIR, YAML_DIR, config["SERVICE"]["openapi_yaml"])
+    API_YAML = ROOT_DIR.joinpath(YAML_DIR, config["SERVICE"]["openapi_yaml"])
     app.app.json_encoder = encoder.JSONEncoder
 
     app.add_api(API_YAML, validate_responses=True)


### PR DESCRIPTION
## Description

This PR fixes a bug that was introduced in #421.

- rename application factory to follow flask conventions (create_fuji_app -> create_app)
- remove obsolete .parent resulting in wrong path in create_app

Related issue: #390


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.