### PR TITLE
ci: add github-actions group to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
   directory: /
   schedule:
     interval: monthly
+  groups:
+    # create a single pull request containing all updates for GitHub Actions
+    github-actions:
+      patterns:
+      - '*'
 - package-ecosystem: pip
   directory: /
   schedule:


### PR DESCRIPTION
## Description

This PR proposes the following changes:

- add a Dependabot group for GitHub Actions. So instead of multiple PRs per Action, you get a single PR combining all Action updates. The feature was added in 2023.

Refs:
- https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

## Types of changes
- [x] Other (please describe): CI

## Checklist

- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.