### PR TITLE
build: set requires-python setting to 3.11 only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,3 @@ updates:
   directory: /
   schedule:
     interval: monthly
-- package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: monthly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.5
-FROM python:3.12-slim
+# at the moment only Python 3.11 is supported
+FROM python:3.11-slim
 
 WORKDIR /usr/src/app
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The service is **in development** and its assessment depends on several factors.
 ![alt text](https://github.com/pangaea-data-publisher/fuji/blob/master/fuji_server/static/main.png?raw=true)
 
 ## Requirements
-[Python](https://www.python.org/downloads/) `3.11+`
+[Python](https://www.python.org/downloads/) `3.11`
 
 ### Google Dataset Search
 * Download the latest Dataset Search corpus file from: <https://www.kaggle.com/googleai/dataset-search-metadata-for-datasets>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ keywords = [
 license = "MIT"
 name = "fuji"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = "~=3.11"  # at the moment only Python 3.11 is supported
 version = "3.1.1"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

The project supports Python 3.11, but not 3.12.

Related issues: #454

## Types of changes
- [x] Build related changes

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
