### PR TITLE
docs: add license headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,13 @@ repos:
     args: [--autofix, --indent, '2']
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.5.4
+  hooks:
+  - id: insert-license
+    types: [python]
+    args: [--license-filepath=docs/license_header.txt]
+    exclude: docs
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.1.11
   hooks:

--- a/docs/license_header.txt
+++ b/docs/license_header.txt
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+
+SPDX-License-Identifier: MIT

--- a/examples/mass_assessment/fuji_mass_eval_template.py
+++ b/examples/mass_assessment/fuji_mass_eval_template.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import json
 import os
 

--- a/fuji_server/__init__.py
+++ b/fuji_server/__init__.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 # flake8: noqa
 from __future__ import absolute_import
 

--- a/fuji_server/__main__.py
+++ b/fuji_server/__main__.py
@@ -1,26 +1,8 @@
 #!/usr/bin/env python3
 
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 import argparse
 import configparser

--- a/fuji_server/app.py
+++ b/fuji_server/app.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import json
 import os
 from pathlib import Path

--- a/fuji_server/config/users.py
+++ b/fuji_server/config/users.py
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 # user dictionary: key = username value = password
 fuji_users = {"marvel": "wonderwoman"}

--- a/fuji_server/controllers/__init__.py
+++ b/fuji_server/controllers/__init__.py
@@ -1,23 +1,3 @@
-################################################################################
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-################################################################################
+# SPDX-License-Identifier: MIT

--- a/fuji_server/controllers/authorization_controller.py
+++ b/fuji_server/controllers/authorization_controller.py
@@ -1,26 +1,7 @@
-################################################################################
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-################################################################################
+# SPDX-License-Identifier: MIT
+
 """
 Controller generated to handled auth operation described at:
 https://connexion.readthedocs.io/en/latest/security.html

--- a/fuji_server/controllers/fair_check.py
+++ b/fuji_server/controllers/fair_check.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import hashlib
 import io
 import logging

--- a/fuji_server/controllers/fair_metric_controller.py
+++ b/fuji_server/controllers/fair_metric_controller.py
@@ -1,29 +1,7 @@
-"""
-FAIR Metric controller.
-"""
-################################################################################
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-################################################################################
+# SPDX-License-Identifier: MIT
+
 from fuji_server.helper.metric_helper import MetricHelper
 
 

--- a/fuji_server/controllers/fair_object_controller.py
+++ b/fuji_server/controllers/fair_object_controller.py
@@ -1,26 +1,6 @@
-################################################################################
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-################################################################################
+# SPDX-License-Identifier: MIT
 
 import datetime
 

--- a/fuji_server/controllers/harvest_controller.py
+++ b/fuji_server/controllers/harvest_controller.py
@@ -1,27 +1,6 @@
-################################################################################
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-################################################################################
-
+# SPDX-License-Identifier: MIT
 
 import connexion
 

--- a/fuji_server/encoder.py
+++ b/fuji_server/encoder.py
@@ -1,4 +1,7 @@
-# from connexion.apps.flask_app import FlaskJSONEncoder
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from connexion.jsonifier import JSONEncoder
 
 from fuji_server.models.base_model_ import Model

--- a/fuji_server/evaluators/__init__.py
+++ b/fuji_server/evaluators/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT

--- a/fuji_server/evaluators/fair_evaluator.py
+++ b/fuji_server/evaluators/fair_evaluator.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from fuji_server.helper.metadata_mapper import Mapper
 from fuji_server.models.fair_result_common_score import FAIRResultCommonScore

--- a/fuji_server/evaluators/fair_evaluator_community_metadata.py
+++ b/fuji_server/evaluators/fair_evaluator_community_metadata.py
@@ -1,25 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+# SPDX-License-Identifier: MIT
 
 from tldextract import extract
 

--- a/fuji_server/evaluators/fair_evaluator_data_access_level.py
+++ b/fuji_server/evaluators/fair_evaluator_data_access_level.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 import re
 

--- a/fuji_server/evaluators/fair_evaluator_data_content_metadata.py
+++ b/fuji_server/evaluators/fair_evaluator_data_content_metadata.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import re
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator

--- a/fuji_server/evaluators/fair_evaluator_data_identifier_included.py
+++ b/fuji_server/evaluators/fair_evaluator_data_identifier_included.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import enum
 import socket
 

--- a/fuji_server/evaluators/fair_evaluator_data_provenance.py
+++ b/fuji_server/evaluators/fair_evaluator_data_provenance.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.helper.metadata_mapper import Mapper

--- a/fuji_server/evaluators/fair_evaluator_file_format.py
+++ b/fuji_server/evaluators/fair_evaluator_file_format.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 import mimetypes
 import re

--- a/fuji_server/evaluators/fair_evaluator_formal_metadata.py
+++ b/fuji_server/evaluators/fair_evaluator_formal_metadata.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.helper.metadata_collector import MetadataSources

--- a/fuji_server/evaluators/fair_evaluator_license.py
+++ b/fuji_server/evaluators/fair_evaluator_license.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import fnmatch
 import re
 

--- a/fuji_server/evaluators/fair_evaluator_metadata_identifier_included.py
+++ b/fuji_server/evaluators/fair_evaluator_metadata_identifier_included.py
@@ -1,25 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+# SPDX-License-Identifier: MIT
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.models.identifier_included import IdentifierIncluded

--- a/fuji_server/evaluators/fair_evaluator_metadata_preservation.py
+++ b/fuji_server/evaluators/fair_evaluator_metadata_preservation.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.models.metadata_preserved import MetadataPreserved

--- a/fuji_server/evaluators/fair_evaluator_minimal_metadata.py
+++ b/fuji_server/evaluators/fair_evaluator_minimal_metadata.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.helper.metadata_collector import MetadataOfferingMethods

--- a/fuji_server/evaluators/fair_evaluator_persistent_identifier_data.py
+++ b/fuji_server/evaluators/fair_evaluator_persistent_identifier_data.py
@@ -1,25 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+# SPDX-License-Identifier: MIT
 
 from fuji_server import Persistence, PersistenceOutput
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator

--- a/fuji_server/evaluators/fair_evaluator_persistent_identifier_metadata.py
+++ b/fuji_server/evaluators/fair_evaluator_persistent_identifier_metadata.py
@@ -1,25 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+# SPDX-License-Identifier: MIT
 
 from fuji_server import Persistence, PersistenceOutput
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator

--- a/fuji_server/evaluators/fair_evaluator_related_resources.py
+++ b/fuji_server/evaluators/fair_evaluator_related_resources.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.helper.identifier_helper import IdentifierHelper

--- a/fuji_server/evaluators/fair_evaluator_searchable.py
+++ b/fuji_server/evaluators/fair_evaluator_searchable.py
@@ -1,25 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+# SPDX-License-Identifier: MIT
 
 from fuji_server import OutputSearchMechanisms
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator

--- a/fuji_server/evaluators/fair_evaluator_semantic_vocabulary.py
+++ b/fuji_server/evaluators/fair_evaluator_semantic_vocabulary.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import fnmatch
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator

--- a/fuji_server/evaluators/fair_evaluator_standardised_protocol_data.py
+++ b/fuji_server/evaluators/fair_evaluator_standardised_protocol_data.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from urllib.parse import urlparse
 

--- a/fuji_server/evaluators/fair_evaluator_standardised_protocol_metadata.py
+++ b/fuji_server/evaluators/fair_evaluator_standardised_protocol_metadata.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from urllib.parse import urlparse
 

--- a/fuji_server/evaluators/fair_evaluator_unique_identifier_data.py
+++ b/fuji_server/evaluators/fair_evaluator_unique_identifier_data.py
@@ -1,25 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+# SPDX-License-Identifier: MIT
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.helper.identifier_helper import IdentifierHelper

--- a/fuji_server/evaluators/fair_evaluator_unique_identifier_metadata.py
+++ b/fuji_server/evaluators/fair_evaluator_unique_identifier_metadata.py
@@ -1,25 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+# SPDX-License-Identifier: MIT
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.helper.identifier_helper import IdentifierHelper

--- a/fuji_server/harvester/__init__.py
+++ b/fuji_server/harvester/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT

--- a/fuji_server/harvester/data_harvester.py
+++ b/fuji_server/harvester/data_harvester.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import io
 import os
 import re

--- a/fuji_server/harvester/metadata_harvester.py
+++ b/fuji_server/harvester/metadata_harvester.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import enum
 import hashlib
 import io

--- a/fuji_server/harvester/repository_harvester.py
+++ b/fuji_server/harvester/repository_harvester.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
+
 class RepositoryHarvester:
     def __init__(self, harvester_type="oai", endpoint_url=""):
         self.type = harvester_type

--- a/fuji_server/helper/__init__.py
+++ b/fuji_server/helper/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT

--- a/fuji_server/helper/catalogue_helper.py
+++ b/fuji_server/helper/catalogue_helper.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import enum
 import logging
 

--- a/fuji_server/helper/catalogue_helper_datacite.py
+++ b/fuji_server/helper/catalogue_helper_datacite.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import logging
 
 import requests

--- a/fuji_server/helper/catalogue_helper_google_datasearch.py
+++ b/fuji_server/helper/catalogue_helper_google_datasearch.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import logging
 import os
 import re

--- a/fuji_server/helper/catalogue_helper_mendeley_data.py
+++ b/fuji_server/helper/catalogue_helper_mendeley_data.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import logging
 
 import requests

--- a/fuji_server/helper/create_google_cache_db.py
+++ b/fuji_server/helper/create_google_cache_db.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server.helper.catalogue_helper_google_datasearch import MetaDataCatalogueGoogleDataSearch
 
 g = MetaDataCatalogueGoogleDataSearch()

--- a/fuji_server/helper/create_google_lists.py
+++ b/fuji_server/helper/create_google_lists.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server.helper.catalogue_helper_google_datasearch import MetaDataCatalogueGoogleDataSearch
 
 g = MetaDataCatalogueGoogleDataSearch()

--- a/fuji_server/helper/datacontent_helper.py
+++ b/fuji_server/helper/datacontent_helper.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT

--- a/fuji_server/helper/identifier_helper.py
+++ b/fuji_server/helper/identifier_helper.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import re
 import urllib
 import uuid

--- a/fuji_server/helper/linked_vocab_helper.py
+++ b/fuji_server/helper/linked_vocab_helper.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import json
 import os
 import re

--- a/fuji_server/helper/log_message_filter.py
+++ b/fuji_server/helper/log_message_filter.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 import logging
 

--- a/fuji_server/helper/metadata_collector.py
+++ b/fuji_server/helper/metadata_collector.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 import enum
 import logging

--- a/fuji_server/helper/metadata_collector_datacite.py
+++ b/fuji_server/helper/metadata_collector_datacite.py
@@ -1,25 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+# SPDX-License-Identifier: MIT
 
 import jmespath
 

--- a/fuji_server/helper/metadata_collector_dublincore.py
+++ b/fuji_server/helper/metadata_collector_dublincore.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 import re
 

--- a/fuji_server/helper/metadata_collector_highwire_eprints.py
+++ b/fuji_server/helper/metadata_collector_highwire_eprints.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 import re
 

--- a/fuji_server/helper/metadata_collector_microdata.py
+++ b/fuji_server/helper/metadata_collector_microdata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import jmespath
 
 from fuji_server.helper.metadata_collector import MetaDataCollector, MetadataFormats

--- a/fuji_server/helper/metadata_collector_opengraph.py
+++ b/fuji_server/helper/metadata_collector_opengraph.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server.helper.metadata_collector import MetaDataCollector, MetadataFormats
 
 

--- a/fuji_server/helper/metadata_collector_ore_atom.py
+++ b/fuji_server/helper/metadata_collector_ore_atom.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import feedparser
 
 from fuji_server.helper.metadata_collector import MetaDataCollector, MetadataFormats

--- a/fuji_server/helper/metadata_collector_rdf.py
+++ b/fuji_server/helper/metadata_collector_rdf.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import json
 import re
 

--- a/fuji_server/helper/metadata_collector_xml.py
+++ b/fuji_server/helper/metadata_collector_xml.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import re
 
 import idutils

--- a/fuji_server/helper/metadata_mapper.py
+++ b/fuji_server/helper/metadata_mapper.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from enum import Enum
 

--- a/fuji_server/helper/metadata_provider.py
+++ b/fuji_server/helper/metadata_provider.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from abc import ABC, abstractmethod
 

--- a/fuji_server/helper/metadata_provider_csw.py
+++ b/fuji_server/helper/metadata_provider_csw.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from lxml import etree
 

--- a/fuji_server/helper/metadata_provider_oai.py
+++ b/fuji_server/helper/metadata_provider_oai.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from lxml import etree
 

--- a/fuji_server/helper/metadata_provider_rss_atom.py
+++ b/fuji_server/helper/metadata_provider_rss_atom.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 import feedparser
 

--- a/fuji_server/helper/metadata_provider_sparql.py
+++ b/fuji_server/helper/metadata_provider_sparql.py
@@ -1,24 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 from urllib.error import HTTPError
 

--- a/fuji_server/helper/metric_helper.py
+++ b/fuji_server/helper/metric_helper.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import logging
 import os
 import re

--- a/fuji_server/helper/preprocessor.py
+++ b/fuji_server/helper/preprocessor.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import json
 import logging
 import mimetypes

--- a/fuji_server/helper/repository_helper.py
+++ b/fuji_server/helper/repository_helper.py
@@ -1,25 +1,6 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+# SPDX-License-Identifier: MIT
 
 import idutils
 from lxml import etree

--- a/fuji_server/helper/request_helper.py
+++ b/fuji_server/helper/request_helper.py
@@ -1,24 +1,7 @@
-# MIT License
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
 #
-# Copyright (c) 2020 PANGAEA (https://www.pangaea.de/)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 import gzip
 import http.cookiejar
 import json

--- a/fuji_server/models/__init__.py
+++ b/fuji_server/models/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT

--- a/fuji_server/models/any_of_fair_results_items.py
+++ b/fuji_server/models/any_of_fair_results_items.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/base_model_.py
+++ b/fuji_server/models/base_model_.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import pprint
 import typing
 

--- a/fuji_server/models/body.py
+++ b/fuji_server/models/body.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/community_endorsed_standard.py
+++ b/fuji_server/models/community_endorsed_standard.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.community_endorsed_standard_output import CommunityEndorsedStandardOutput

--- a/fuji_server/models/community_endorsed_standard_output.py
+++ b/fuji_server/models/community_endorsed_standard_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/community_endorsed_standard_output_inner.py
+++ b/fuji_server/models/community_endorsed_standard_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/core_metadata.py
+++ b/fuji_server/models/core_metadata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.core_metadata_output import CoreMetadataOutput

--- a/fuji_server/models/core_metadata_output.py
+++ b/fuji_server/models/core_metadata_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.output_core_metadata_found import OutputCoreMetadataFound

--- a/fuji_server/models/data_access_level.py
+++ b/fuji_server/models/data_access_level.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.data_access_output import DataAccessOutput

--- a/fuji_server/models/data_access_output.py
+++ b/fuji_server/models/data_access_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/data_content_metadata.py
+++ b/fuji_server/models/data_content_metadata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.data_content_metadata_output import DataContentMetadataOutput

--- a/fuji_server/models/data_content_metadata_output.py
+++ b/fuji_server/models/data_content_metadata_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.data_content_metadata_output_inner import DataContentMetadataOutputInner

--- a/fuji_server/models/data_content_metadata_output_inner.py
+++ b/fuji_server/models/data_content_metadata_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/data_file_format.py
+++ b/fuji_server/models/data_file_format.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.data_file_format_output import DataFileFormatOutput

--- a/fuji_server/models/data_file_format_output.py
+++ b/fuji_server/models/data_file_format_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.data_file_format_output_inner import DataFileFormatOutputInner  # noqa: F401

--- a/fuji_server/models/data_file_format_output_inner.py
+++ b/fuji_server/models/data_file_format_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/data_provenance.py
+++ b/fuji_server/models/data_provenance.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.data_provenance_output import DataProvenanceOutput

--- a/fuji_server/models/data_provenance_output.py
+++ b/fuji_server/models/data_provenance_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.data_provenance_output_inner import DataProvenanceOutputInner

--- a/fuji_server/models/data_provenance_output_inner.py
+++ b/fuji_server/models/data_provenance_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/debug.py
+++ b/fuji_server/models/debug.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/fair_result_common.py
+++ b/fuji_server/models/fair_result_common.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.fair_result_common_score import FAIRResultCommonScore

--- a/fuji_server/models/fair_result_common_score.py
+++ b/fuji_server/models/fair_result_common_score.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/fair_result_evaluation_criterium.py
+++ b/fuji_server/models/fair_result_evaluation_criterium.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.fair_result_common_score import FAIRResultCommonScore

--- a/fuji_server/models/fair_result_evaluation_criterium_requirements.py
+++ b/fuji_server/models/fair_result_evaluation_criterium_requirements.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/fair_results.py
+++ b/fuji_server/models/fair_results.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from datetime import datetime
 
 # from fuji_server.models.any_of_fair_results_results_items import AnyOfFAIRResultsResultsItems

--- a/fuji_server/models/formal_metadata.py
+++ b/fuji_server/models/formal_metadata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/formal_metadata_output.py
+++ b/fuji_server/models/formal_metadata_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.formal_metadata_output_inner import FormalMetadataOutputInner  # noqa: F401

--- a/fuji_server/models/formal_metadata_output_inner.py
+++ b/fuji_server/models/formal_metadata_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/harvest.py
+++ b/fuji_server/models/harvest.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/harvest_results.py
+++ b/fuji_server/models/harvest_results.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.harvest_results_metadata import HarvestResultsMetadata

--- a/fuji_server/models/harvest_results_metadata.py
+++ b/fuji_server/models/harvest_results_metadata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/identifier_included.py
+++ b/fuji_server/models/identifier_included.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/identifier_included_output.py
+++ b/fuji_server/models/identifier_included_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.identifier_included_output_inner import IdentifierIncludedOutputInner

--- a/fuji_server/models/identifier_included_output_inner.py
+++ b/fuji_server/models/identifier_included_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/license.py
+++ b/fuji_server/models/license.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/license_output.py
+++ b/fuji_server/models/license_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.license_output_inner import LicenseOutputInner  # noqa: F401

--- a/fuji_server/models/license_output_inner.py
+++ b/fuji_server/models/license_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/metadata_preserved.py
+++ b/fuji_server/models/metadata_preserved.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/metadata_preserved_output.py
+++ b/fuji_server/models/metadata_preserved_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/metric.py
+++ b/fuji_server/models/metric.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from datetime import date
 
 from fuji_server import util

--- a/fuji_server/models/metrics.py
+++ b/fuji_server/models/metrics.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.metric import Metric

--- a/fuji_server/models/output_core_metadata_found.py
+++ b/fuji_server/models/output_core_metadata_found.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/output_search_mechanisms.py
+++ b/fuji_server/models/output_search_mechanisms.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/persistence.py
+++ b/fuji_server/models/persistence.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/persistence_output.py
+++ b/fuji_server/models/persistence_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.persistence_output_inner import PersistenceOutputInner

--- a/fuji_server/models/persistence_output_inner.py
+++ b/fuji_server/models/persistence_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/related_resource.py
+++ b/fuji_server/models/related_resource.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/related_resource_output.py
+++ b/fuji_server/models/related_resource_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.related_resource_output_inner import RelatedResourceOutputInner  # noqa: F401

--- a/fuji_server/models/related_resource_output_inner.py
+++ b/fuji_server/models/related_resource_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/searchable.py
+++ b/fuji_server/models/searchable.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/searchable_output.py
+++ b/fuji_server/models/searchable_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.output_search_mechanisms import OutputSearchMechanisms

--- a/fuji_server/models/semantic_vocabulary.py
+++ b/fuji_server/models/semantic_vocabulary.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/semantic_vocabulary_output.py
+++ b/fuji_server/models/semantic_vocabulary_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.semantic_vocabulary_output_inner import SemanticVocabularyOutputInner  # noqa: F401

--- a/fuji_server/models/semantic_vocabulary_output_inner.py
+++ b/fuji_server/models/semantic_vocabulary_output_inner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/standardised_protocol_data.py
+++ b/fuji_server/models/standardised_protocol_data.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/standardised_protocol_data_output.py
+++ b/fuji_server/models/standardised_protocol_data_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/standardised_protocol_metadata.py
+++ b/fuji_server/models/standardised_protocol_metadata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/standardised_protocol_metadata_output.py
+++ b/fuji_server/models/standardised_protocol_metadata_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/models/uniqueness.py
+++ b/fuji_server/models/uniqueness.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 from fuji_server.models.debug import Debug

--- a/fuji_server/models/uniqueness_output.py
+++ b/fuji_server/models/uniqueness_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from fuji_server import util
 from fuji_server.models.base_model_ import Model
 

--- a/fuji_server/util.py
+++ b/fuji_server/util.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import datetime
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT

--- a/tests/api/test_urls.py
+++ b/tests/api/test_urls.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import configparser

--- a/tests/controllers/test_fair_check.py
+++ b/tests/controllers/test_fair_check.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import pytest
 
 from fuji_server.controllers.fair_check import FAIRCheck

--- a/tests/functional/test_evaluation.py
+++ b/tests/functional/test_evaluation.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/helper/test_preprocessor.py
+++ b/tests/helper/test_preprocessor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 """
 Here we test the Preprocessor class which provides the reference data for a server
 

--- a/tests/models/test_harvest.py
+++ b/tests/models/test_harvest.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)
+#
+# SPDX-License-Identifier: MIT
+
 import pytest
 
 from fuji_server.models.harvest import Harvest


### PR DESCRIPTION
## Description

This PR adds a new pre-commit hook, that adds this license headers to each python module:

```python
# SPDX-FileCopyrightText: 2020 PANGAEA (https://www.pangaea.de/)

# SPDX-License-Identifier: MIT
```

This should be sufficient, no need to copy the whole MIT license text into a module.

Two things I am unsure about:

- the copyright years though. You want to change those to the year the module was created, e.g. 2021, 2022, etc?
- the copyright text could potentially include the list of authors per module

What do you think?

## Types of changes
- [x] Build related changes
- [x] Documentation content changes

## Checklist
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
