### PR TITLE
ci: add coverage badge and report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
 
   tests:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
@@ -84,9 +86,6 @@ jobs:
         python -m pip install --upgrade hatch
     - name: Run test suite with coverage
       run: hatch run cov-ci
-    - name: Generate badges
-      if: always()
-      run: hatch run badges
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v4
@@ -101,6 +100,15 @@ jobs:
         name: coverage-results
         retention-days: 1
         path: pytest-cobertura.xml
+    - run: rm ./reports/coverage/.gitignore
+    - name: Generate coverage badge
+      if: github.ref == 'refs/heads/master'
+      run: hatch run cov-badge
+    - name: Deploy reports to GitHub Pages
+      if: github.ref == 'refs/heads/master'
+      uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
+      with:
+        folder: ./reports
 
   event_file:
     runs-on: ubuntu-22.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
   rev: v4.5.0
   hooks:
   - id: end-of-file-fixer
+    exclude_types: [svg]
   - id: mixed-line-ending
     types: [python]
   - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Developers: [Robert Huber](mailto:rhuber@marum.de), [Anusuriya Devaraju](mailto:
 Thanks to [Heinz-Alexander Fuetterer](https://github.com/afuetterer) for his contributions and his help in cleaning up the code.
 
 [![CI](https://github.com/pangaea-data-publisher/fuji/actions/workflows/ci.yml/badge.svg)](https://github.com/pangaea-data-publisher/fuji/actions/workflows/ci.yml)
+[![Coverage](https://pangaea-data-publisher.github.io/fuji/coverage/coveragebadge.svg)](https://pangaea-data-publisher.github.io/fuji/coverage/)
+
 [![Publish Docker image](https://github.com/pangaea-data-publisher/fuji/actions/workflows/publish-docker.yml/badge.svg)](https://github.com/pangaea-data-publisher/fuji/actions/workflows/publish-docker.yml)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4063720.svg)](https://doi.org/10.5281/zenodo.4063720)
-
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ report = [
   "jupyter~=1.0"
 ]
 testing = [
-  "genbadge[tests]~=1.1",
+  "genbadge[coverage]~=1.1",
   "pytest~=7.4",
   "pytest-cov~=4.1",
   "pytest-randomly~=3.15",
@@ -122,10 +122,9 @@ features = [
 ]
 
 [tool.hatch.envs.default.scripts]
-badges = "genbadge tests --input-file=pytest-junit.xml"
 cov = "pytest --cov {args}"
-cov-ci = "pytest --cov --junitxml=pytest-junit.xml --cov-report=xml:pytest-cobertura.xml {args}"
-cov-html = "pytest --cov --cov-report=html {args}"
+cov-badge = "genbadge coverage --input-file=pytest-cobertura.xml --output-file=./reports/coverage/coveragebadge.svg"
+cov-ci = "pytest --cov --junitxml=pytest-junit.xml --cov-report=xml:pytest-cobertura.xml --cov-report=html:./reports/coverage/ {args}"
 lint = "pre-commit run --all-files --color=always {args}"
 test = "pytest {args}"
 


### PR DESCRIPTION
## Description

This PR adds a coverage badge to the README showing the percentage of code coverage in the project. Also it deploys a code coverage HTML report to GitHub pages.

Example: https://afuetterer.github.io/fuji/coverage/

## Types of changes
- [x] Other (please describe): CI

## Checklist
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.