### PR TITLE
build: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: end-of-file-fixer
     exclude_types: [svg]
@@ -15,7 +15,7 @@ repos:
   - id: file-contents-sorter
     files: ^fuji_server\/data\/.*.txt$
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.12.0
+  rev: v2.13.0
   hooks:
   - id: pretty-format-ini
     args: [--autofix]
@@ -24,14 +24,14 @@ repos:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
 - repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: v1.5.4
+  rev: v1.5.5
   hooks:
   - id: insert-license
     types: [python]
     args: [--license-filepath=docs/license_header.txt]
     exclude: docs
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.11
+  rev: v0.5.1
   hooks:
   - id: ruff
     args: [--fix, --show-fixes, --exit-non-zero-on-fix]

--- a/fuji_server/helper/metadata_collector_rdf.py
+++ b/fuji_server/helper/metadata_collector_rdf.py
@@ -301,9 +301,9 @@ class MetaDataCollectorRdf(MetaDataCollector):
                                     if isinstance(rdf_response.get("@context"), list):
                                         for ctxi, ctxt in enumerate(rdf_response.get("@context")):
                                             if "schema.org" in ctxt:
-                                                rdf_response["@context"][
-                                                    ctxi
-                                                ] = "https://schema.org/docs/jsonldcontext.json"
+                                                rdf_response["@context"][ctxi] = (
+                                                    "https://schema.org/docs/jsonldcontext.json"
+                                                )
                                     if isinstance(rdf_response.get("@context"), str):
                                         if "schema.org" in rdf_response.get("@context"):
                                             rdf_response["@context"] = "https://schema.org/docs/jsonldcontext.json"

--- a/fuji_server/helper/request_helper.py
+++ b/fuji_server/helper/request_helper.py
@@ -425,9 +425,9 @@ class RequestHelper:
                                                     xmltree = lxml.etree.XML(self.response_content, xmlparser)
                                                     root_element = xmltree.tag
                                                     if content_truncated:
-                                                        self.parse_response = (
-                                                            self.response_content
-                                                        ) = lxml.etree.tostring(xmltree)
+                                                        self.parse_response = self.response_content = (
+                                                            lxml.etree.tostring(xmltree)
+                                                        )
                                                 except Exception:
                                                     self.logger.warning(
                                                         "%s : Parsing XML document failed !" % metric_id

--- a/fuji_server/util.py
+++ b/fuji_server/util.py
@@ -18,7 +18,7 @@ def _deserialize(data, klass):
 
     if klass in (int, float, str, bool):
         return _deserialize_primitive(data, klass)
-    elif klass == object:
+    elif klass is object:
         return _deserialize_object(data)
     elif klass == datetime.date:
         return deserialize_date(data)
@@ -30,9 +30,9 @@ def _deserialize(data, klass):
     #     if klass.__extra__ == dict:
     #         return _deserialize_dict(data, klass.__args__[1])
     elif hasattr(klass, "__origin__"):
-        if klass.__origin__ == list or klass.__origin__ == list:
+        if klass.__origin__ is list or klass.__origin__ is list:
             return _deserialize_list(data, klass.__args__[0])
-        if klass.__origin__ == dict:
+        if klass.__origin__ is dict:
             return _deserialize_dict(data, klass.__args__[1])
     else:
         return deserialize_model(data, klass)

--- a/metrics_configuration.md
+++ b/metrics_configuration.md
@@ -16,7 +16,7 @@ Copy the YAML content of this metric file to a new metric file and save the file
 
 To define own metrics you can restrict the number of metrics and add configuration options to a limited number of existing metrics.
 
-### Configure metrics and tests to be performed 
+### Configure metrics and tests to be performed
 
 To restrict metrics choose those you want to use from the 0.6 list of metrics and tests and simply delete tests or metrics which you do not wish to be performed during your assessments.
 
@@ -26,12 +26,12 @@ For all metrics and tests you can change the YAML properties*metric_short_name*,
 
 For some tests you can define additional parameters. For example, one can specify exactly which metadata elements, licenses, metadata standards or vocabularies are expected.
 
-Generally, these specifications are defined using the YAML property *community_requirements* which has to be a dictionary containing the subproperties *target*, *modality*, and  *required*. 
+Generally, these specifications are defined using the YAML property *community_requirements* which has to be a dictionary containing the subproperties *target*, *modality*, and  *required*.
 
 * *target* defines the test targets, defined in the F-UJI ontology, such as licenses, metadata properties etc. which is represented by a controlled list of values which is used for tests by default.
 * *required* has to be a list which defines the necessary property values
-* *modality* defines if *all* or *any* of *required* values need to be present to pass the test. 
-*match* specifies how matching values are identified: *wildcard* for wildcard-like match rules like 'test*'; *full* when a full match is required. 
+* *modality* defines if *all* or *any* of *required* values need to be present to pass the test.
+*match* specifies how matching values are identified: *wildcard* for wildcard-like match rules like 'test*'; *full* when a full match is required.
 *target_property* additionally defines the property of the *target* object in which matches are searched for, by default the property *name* or *label* is used for this purpose.
 *modality* and *match* are currently not yet implemented, thus still hardcoded :( but may be implemented in future versions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,3 +167,15 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["fuji_server", "tests"]
+
+[tool.ruff.lint.per-file-ignores]
+# Note: ruff does not understand, that the logger, which gets passed through multiple inheritance is actually
+# a logger instance. It would not apply f-strings to logging messages. But let's ignore UP031 and UP032 for now.
+"fuji_server/evaluators/*.py" = [
+  "UP031",  # printf-string-formatting
+  "UP032"  # f-string
+]
+"fuji_server/helper/*.py" = [
+  "UP031",  # printf-string-formatting
+  "UP032"  # f-string
+]

--- a/tests/helper/test_preprocessor.py
+++ b/tests/helper/test_preprocessor.py
@@ -19,6 +19,7 @@ markers. These tests can be run prior to a release manually.
 They mock the fuji_server/data path to not override the files under fuji server
 
 """
+
 import json
 from typing import Any
 


### PR DESCRIPTION
## Description

This PR updates the pre-commit hooks. It also fixes the currently broken lint job status by applying the pre-commit hooks on the code base.
Lastly I added a few rules to the ignore list and added a note. `ruff` usually does not fix logging messages to use f-strings, but with this code base, it does not understand that self.logger in an inherited class is actually a logger. I can't think of a way to fix this right now, so I added those rules to ignore list.

## Types of changes
- [x] Code style update (formatting, renaming)
- [x] Build related changes

## Checklist

- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
