### PR TITLE
ci: replace custom lint job with pre-commit/action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,14 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   PYTHONUNBUFFERED: 1
   FORCE_COLOR: 1 # colored output by pytest etc.
-  CLICOLOR_FORCE: 1 # colored output by ruff
 
-permissions:
-  contents: read
+permissions: {} # Set permissions at the job level.
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,26 +48,17 @@ jobs:
   #       SPHINXOPTS='-n' make -C docs html
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
-    - name: Cache python dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.cache/pre-commit
-        key: lint-${{ hashFiles('.pre-commit-config.yaml', 'pyproject.toml') }}
-        restore-keys: |
-          lint-
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    - run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install hatch
-    - run: hatch run lint
+        cache: pip
+    - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --all-files --color=always
 
   tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,34 +17,6 @@ permissions: {} # Set permissions at the job level.
 
 jobs:
 
-  # TODO: disable docs build until decision is made
-
-  # docs:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Set up Python 3.11
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.11'
-  #   - name: Cache python dependencies
-  #     uses: actions/cache@v4
-  #     with:
-  #       path: ~/.cache/pip
-  #       key: pip-docs-${{ hashFiles('pyproject.toml') }}
-  #       restore-keys: |
-  #         pip-docs-
-  #   - name: Install python dependencies
-  #     run: |
-  #       python -m pip install .[docs]
-  #       python -m pip show fuji
-  #   - name: Build documentation
-  #     env:
-  #       READTHEDOCS: 'True'
-  #     run: |
-  #       # TODO: add W flag back after fixing warnings
-  #       SPHINXOPTS='-n' make -C docs html
-
   lint:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Description

This PR replaces the custom lint job with the official [pre-commit/action](https://github.com/pre-commit/action), which takes care of caching as well.

## Types of changes
- [x] Other (please describe): CI

## Checklist
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
