### PR TITLE
build: switch to python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: pip
     - uses: pre-commit/action@v3.0.1
       with:
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: pip
     - run: |
         python -m pip install --upgrade pip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ If you are proposing a feature:
 
 Ready to contribute?
 
-You need Python 3.11+ and [hatch](https://github.com/pypa/hatch). You can install it globally with [pipx](https://github.com/pypa/pipx):
+You need Python 3.12+ and [hatch](https://github.com/pypa/hatch). You can install it globally with [pipx](https://github.com/pypa/pipx):
 
 ```console
 $ pipx install hatch
@@ -99,7 +99,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should include tests.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
-3. The pull request should work for Python >= 3.11. Check
+3. The pull request should work for Python >= 3.12. Check
    <https://github.com/pangaea-data-publisher/fuji/pulls>
    and make sure that all the tests pass.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1.5
-# at the moment only Python 3.11 is supported
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /usr/src/app
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The service is **in development** and its assessment depends on several factors.
 ![alt text](https://github.com/pangaea-data-publisher/fuji/blob/master/fuji_server/static/main.png?raw=true)
 
 ## Requirements
-[Python](https://www.python.org/downloads/) `3.11`
+[Python](https://www.python.org/downloads/) `3.12`
 
 ### Google Dataset Search
 * Download the latest Dataset Search corpus file from: <https://www.kaggle.com/googleai/dataset-search-metadata-for-datasets>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering :: Information Analysis"
 ]
 dependencies = [
@@ -59,7 +59,7 @@ keywords = [
 license = "MIT"
 name = "fuji"
 readme = "README.md"
-requires-python = "~=3.11"  # at the moment only Python 3.11 is supported
+requires-python = "~=3.12"  # at the moment only Python 3.12 is supported
 version = "3.3.0"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

Fixes #516

I don't know why the tests failed before, but there was at least one dependency blocking from moving to Python 3.12.

It seems to be working though. What do you think?

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Build related changes

## Checklist

- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
