### PR TITLE
build: switch to hatch test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - run: |
         python -m pip install --upgrade pip
         python -m pip install hatch
-    - name: Run test suite with coverage
-      run: hatch run cov --cov-report=xml
+    - name: Run test suite in parallel with measuring code coverage
+      run: hatch test --cover-quiet --parallel
     - name: Upload coverage data to coveralls.io
       uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Here's how to set up F-UJI for local development.
    tests:
     ```console
     $ hatch run lint
-    $ hatch run test
+    $ hatch test
     ```
 
 6. Commit your changes and push your branch to GitHub:
@@ -108,8 +108,8 @@ Before you submit a pull request, check that it meets these guidelines:
 To run a subset of tests:
 
 ```console
-$ hatch run test tests/api
-$ hatch run test -m smoke
+$ hatch test tests/api
+$ hatch test -m smoke
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,27 +64,14 @@ requires-python = "~=3.11"  # at the moment only Python 3.11 is supported
 version = "3.2.2"
 
 [project.optional-dependencies]
-dev = [
-  "fuji[lint,testing]"
-]
 docs = [
   "myst-parser~=3.0",
   "sphinx~=7.2",
   "sphinx-rtd-theme~=2.0"
 ]
-lint = [
-  "pre-commit~=3.4"
-]
 report = [
   "bokeh~=3.2",
   "jupyter~=1.0"
-]
-testing = [
-  "pytest~=8.0",
-  "pytest-cov~=5.0",
-  "pytest-randomly~=3.15",
-  "pytest-recording~=0.13",
-  "pytest-xdist~=3.3"
 ]
 
 [project.urls]
@@ -115,18 +102,32 @@ include = [
 packages = ["fuji_server"]
 
 [tool.hatch.envs.default]
-features = [
-  "lint",
-  "testing"
+dependencies = [
+  "pre-commit"
 ]
 post-install-commands = [
   "pre-commit install"
 ]
 
 [tool.hatch.envs.default.scripts]
-cov = "pytest --cov {args}"
 lint = "pre-commit run --all-files --color=always {args}"
-test = "pytest {args}"
+
+[tool.hatch.envs.hatch-test]
+# Ref: https://hatch.pypa.io/latest/config/internal/testing/
+extra-dependencies = [
+  "pytest-recording~=0.13"
+]
+randomize = true  # run tests in random order
+
+[tool.hatch.envs.hatch-test.scripts]
+cov-combine = """
+coverage combine
+coverage xml
+"""
+cov-report = "coverage report"
+# Ref: https://hatch.pypa.io/latest/config/internal/testing/#scripts
+run = "pytest{env:HATCH_TEST_ARGS:} {args}"
+run-cov = "coverage run -m pytest{env:HATCH_TEST_ARGS:} {args}"
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
## Description

This PR moves from the custom optional dependency group testing to using the hatch testing config. The tests now run in random order as a default to find tests that depend on a certain order of running.

Instead of

```console
$ hatch run test
```

You can now do

```console
$ hatch test
```

Instead of 

```console
$ hatch run cov
```

It is

```console
$ hatch test --cover # or
$ hatch test -c 
```

Tests can run in parallel with

```console
$ hatch test --parallel # or
$ hatch test -p
```

These can be combined to:

```console
$ hatch test --cover --parallel # or
$ hatch test -cp
```

What do you think?

## Types of changes
- [x] Build related changes

## Checklist
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.