### PR TITLE
build: switch to connexion middleware for cors

### DIFF
--- a/fuji_server/app.py
+++ b/fuji_server/app.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import connexion
 from connexion.jsonifier import Jsonifier
-from flask_cors import CORS
+from connexion.middleware import MiddlewarePosition
+from starlette.middleware.cors import CORSMiddleware
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from fuji_server import encoder
@@ -27,10 +28,19 @@ def create_app(config):
 
     API_YAML = ROOT_DIR.joinpath(YAML_DIR, config["SERVICE"]["openapi_yaml"])
 
+    # Ref: https://connexion.readthedocs.io/en/latest/cookbook.html#cors
+    if os.getenv("ENABLE_CORS", "False").lower() == "true":
+        app.add_middleware(
+            CORSMiddleware,
+            position=MiddlewarePosition.BEFORE_EXCEPTION,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
     app.add_api(API_YAML, validate_responses=True, jsonifier=myjsonifier)
 
     app.app.wsgi_app = ProxyFix(app.app.wsgi_app, x_for=1, x_host=1)
-    if os.getenv("ENABLE_CORS", "False").lower() == "true":
-        CORS(app.app)
 
     return app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "connexion[flask,uvicorn,swagger-ui]~=3.0",
   "extruct~=0.17.0",
   "feedparser~=6.0",
-  "flask-cors~=4.0",
   "flask-limiter~=3.5",
   "hashid~=3.1.4",
   "idutils~=1.2",


### PR DESCRIPTION
## Description

According to the connexion docs and their migration guide to 3.0, it is no longer possible to use `Flask-Cors`. I added the snippet from their docs and removed Flask-Cors from the deps.

Refs:
- https://connexion.readthedocs.io/en/latest/v3.html#flask-extensions-and-wsgi-middleware
- https://connexion.readthedocs.io/en/latest/cookbook.html#cors

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
