### PR TITLE
ci: prefer action-pre-commit-uv for lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-        cache: pip
-    - uses: pre-commit/action@v3.0.1
-      with:
-        extra_args: --all-files --color=always
+    - uses: tox-dev/action-pre-commit-uv@246b66536e366bb885f52d61983bf32f7c95e8b1 # v1.0.3
 
   tests:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->

## Description

This PR replaces the pre-commit action with the one from the tox devs that uses pre-commit-uv, which uses to install dependencies in their venvs, which speeds up the install step a lot.

## Types of changes
- [x] Other (please describe): CI

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- This pull request template is adapted from:
<!--- "open-source-templates", https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- "amazing-github-template", https://github.com/dec0dOS/amazing-github-template (MIT License). --->
