### PR TITLE
chore: deal with idutils deprecation warnings

### DIFF
--- a/fuji_server/evaluators/fair_evaluator_license.py
+++ b/fuji_server/evaluators/fair_evaluator_license.py
@@ -5,8 +5,8 @@
 import fnmatch
 import re
 
-import idutils
 import Levenshtein
+from idutils import is_url
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.models.license import License
@@ -55,7 +55,7 @@ class FAIREvaluatorLicense(FAIREvaluator):
                 licence_valid = False
                 license_output = LicenseOutputInner()
                 if isinstance(license, str):
-                    isurl = idutils.is_url(license)
+                    isurl = is_url(license)
                     if isurl:
                         iscc, generic_cc = self.isCreativeCommonsLicense(license, self.metric_identifier)
                         if iscc:
@@ -117,7 +117,7 @@ class FAIREvaluatorLicense(FAIREvaluator):
 
     def isLicense(self, value, metric_id):
         islicense = False
-        isurl = idutils.is_url(value)
+        isurl = is_url(value)
         spdx_html = None
         spdx_osi = None
         if isurl:

--- a/fuji_server/evaluators/fair_evaluator_license_file.py
+++ b/fuji_server/evaluators/fair_evaluator_license_file.py
@@ -6,9 +6,9 @@ import fnmatch
 import re
 from pathlib import Path
 
-import idutils
 import Levenshtein
 import lxml.etree as ET
+from idutils import is_url
 
 from fuji_server.evaluators.fair_evaluator import FAIREvaluator
 from fuji_server.models.license import License
@@ -64,7 +64,7 @@ class FAIREvaluatorLicenseFile(FAIREvaluator):
                 licence_valid = False
                 license_output = LicenseOutputInner()
                 if isinstance(license, str):
-                    isurl = idutils.is_url(license)
+                    isurl = is_url(license)
                     if isurl:
                         iscc, generic_cc = self.isCreativeCommonsLicense(license, self.metric_identifier)
                         if iscc:

--- a/fuji_server/harvester/data_harvester.py
+++ b/fuji_server/harvester/data_harvester.py
@@ -9,7 +9,7 @@ import ssl
 import threading
 import urllib
 
-import idutils
+from idutils import is_url
 from tika import parser
 
 from fuji_server.helper.identifier_helper import IdentifierHelper
@@ -40,7 +40,7 @@ class DataHarvester:
         # replace local urls with full path from landing_page URI
         self.logger.info("FsF-R1-01MD : Trying to complete local file name with full path info using landing page URI")
         if self.landing_page:
-            if idutils.is_url(self.landing_page):
+            if is_url(self.landing_page):
                 try:
                     path = os.path.dirname(self.landing_page)
                     url = path + "/" + url
@@ -159,7 +159,7 @@ class DataHarvester:
         # header["Range"] = "bytes=0-" + str(self.max_download_size)
         url = urldict.get("url")
         if url:
-            if not idutils.is_url(url):
+            if not is_url(url):
                 url = self.expand_url(url)
             # print("Downloading.. ", url)
             response = None

--- a/fuji_server/helper/identifier_helper.py
+++ b/fuji_server/helper/identifier_helper.py
@@ -7,7 +7,8 @@ import urllib
 import uuid
 
 import hashid
-import idutils
+from idutils import detect_identifier_schemes, is_urn, normalize_pid
+from idutils import to_url as _to_url
 
 from fuji_server.helper.preprocessor import Preprocessor
 from fuji_server.helper.request_helper import AcceptTypes, RequestHelper
@@ -74,7 +75,7 @@ class IdentifierHelper:
                     candidateurn = urnid + str(urnsplit[2])
                     candresolver = re.sub(r"https?://", "", urnsplit[0])
                     if candresolver in self.URN_RESOLVER.values():
-                        if idutils.is_urn(candidateurn):
+                        if is_urn(candidateurn):
                             self.identifier_schemes = ["url", "urn"]
                             self.preferred_schema = "urn"
                             self.normalized_id = candidateurn
@@ -152,7 +153,7 @@ class IdentifierHelper:
 
                 # idutils check
                 if not self.identifier_schemes:
-                    self.identifier_schemes = idutils.detect_identifier_schemes(self.identifier)
+                    self.identifier_schemes = detect_identifier_schemes(self.identifier)
                     if "url" not in self.identifier_schemes and idparts.scheme in ["http", "https"]:
                         self.identifier_schemes.append("url")
                 # verify handles
@@ -173,7 +174,7 @@ class IdentifierHelper:
                                     # self.identifier_schemes.remove('url')
                             self.preferred_schema = self.identifier_schemes[0]
                             if not self.normalized_id:
-                                self.normalized_id = idutils.normalize_pid(self.identifier, self.preferred_schema)
+                                self.normalized_id = normalize_pid(self.identifier, self.preferred_schema)
                             if not self.identifier_url:
                                 self.identifier_url = self.to_url(self.identifier, self.preferred_schema)
                             # print('IDURL ',self.identifier_url, self.preferred_schema)
@@ -245,7 +246,7 @@ class IdentifierHelper:
             if schema == "ark":
                 idurl = id
             else:
-                idurl = idutils.to_url(id, schema)
+                idurl = _to_url(id, schema)
             if schema in ["doi", "handle"]:
                 idurl = idurl.replace("http:", "https:")
         except Exception as e:

--- a/fuji_server/helper/metadata_collector_rdf.py
+++ b/fuji_server/helper/metadata_collector_rdf.py
@@ -7,9 +7,9 @@ import re
 import urllib
 
 import dateutil
-import idutils
 import rdflib
 import requests
+from idutils import is_url
 from rdflib import RDFS, SKOS, Namespace
 from rdflib.namespace import (
     DC,
@@ -112,7 +112,7 @@ class MetaDataCollectorRdf(MetaDataCollector):
             # namespaces from mentioned objects and subjects uris (best try)
             for uri in alluris:
                 uri = str(uri)
-                if idutils.is_url(uri):
+                if is_url(uri):
                     for known_pattern in known_namespace_regex:
                         kpm = re.match(known_pattern, uri)
                         if kpm:
@@ -915,7 +915,7 @@ class MetaDataCollectorRdf(MetaDataCollector):
                     or graph.value(dist, SDO.fileSize)
                 )
                 if durl or dtype or dsize:
-                    if idutils.is_url(str(durl)):
+                    if is_url(str(durl)):
                         if dtype:
                             dtype = "/".join(str(dtype).split("/")[-2:])
                     schema_metadata["object_content_identifier"].append(
@@ -1144,7 +1144,7 @@ class MetaDataCollectorRdf(MetaDataCollector):
                     )
                     dsize = graph.value(dist, DCAT.byteSize)
                 if durl or dtype or dsize:
-                    if idutils.is_url(str(durl)):
+                    if is_url(str(durl)):
                         dtype = "/".join(str(dtype).split("/")[-2:])
                     dcat_metadata["object_content_identifier"].append(
                         {"url": str(durl), "type": dtype, "size": str(dsize), "service": str(dservice)}

--- a/fuji_server/helper/metadata_collector_xml.py
+++ b/fuji_server/helper/metadata_collector_xml.py
@@ -4,8 +4,8 @@
 
 import re
 
-import idutils
 import lxml
+from idutils import is_url, is_urn
 
 from fuji_server.helper.metadata_collector import MetaDataCollector, MetadataFormats, MetadataOfferingMethods
 from fuji_server.helper.metadata_mapper import Mapper
@@ -61,13 +61,13 @@ class MetaDataCollectorXML(MetaDataCollector):
             for el in elr:
                 if str(el).strip():
                     if el not in founduris:
-                        if idutils.is_url(el) or idutils.is_urn(el):
+                        if is_url(el) or is_urn(el):
                             founduris.append(str(el))
             # all attribute values
             alr = metatree.xpath("//@*")
             for al in alr:
                 if al not in founduris:
-                    if idutils.is_url(al) or idutils.is_urn(al):
+                    if is_url(al) or is_urn(al):
                         founduris.append(str(al))
             founduris = list(set(founduris))
             # xpath

--- a/fuji_server/helper/repository_helper.py
+++ b/fuji_server/helper/repository_helper.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-import idutils
+from idutils import is_doi, normalize_pid
 from lxml import etree
 from tldextract import extract
 
@@ -32,8 +32,8 @@ class RepositoryHelper:
         if self.client_id:  # and self.pid_scheme:
             re3doi = RepositoryHelper.DATACITE_REPOSITORIES.get(self.client_id)  # {client_id,re3doi}
             if re3doi:
-                if idutils.is_doi(re3doi):
-                    short_re3doi = idutils.normalize_pid(re3doi, scheme="doi")  # https://doi.org/10.17616/R3XS37
+                if is_doi(re3doi):
+                    short_re3doi = normalize_pid(re3doi, scheme="doi")  # https://doi.org/10.17616/R3XS37
                 else:
                     re3doi = None
 


### PR DESCRIPTION
In the test runs there were a lot of warnings, among them a few deprecation warnings from `idutils`, e.g. 
```
tests: fuji_server/evaluators/fair_evaluator_license.py#L8
Implicit imports (e.g., 'import idutils; idutils.function;') might be removed in the next major version. Please use explicit imports (e.g., 'from idutils import function;') instead.
```

This means, you can no longer except to use `import idutils`. This PR makes the imports from idutils explicit.

