### PR TITLE
chore: deal with soup deprecation warnings

### DIFF
--- a/fuji_server/controllers/fair_check.py
+++ b/fuji_server/controllers/fair_check.py
@@ -592,7 +592,7 @@ class FAIRCheck:
         # check if javascript generated content only:
         try:
             soup = BeautifulSoup(response_content, features="html.parser")
-            script_content = soup.findAll("script")
+            script_content = soup.find_all("script")
             for script in soup(["script", "style", "title", "noscript"]):
                 script.extract()
 

--- a/fuji_server/harvester/metadata_harvester.py
+++ b/fuji_server/harvester/metadata_harvester.py
@@ -676,7 +676,7 @@ class MetadataHarvester:
         # check if javascript generated content only:
         try:
             soup = BeautifulSoup(response_content, features="html.parser")
-            script_content = soup.findAll("script")
+            script_content = soup.find_all("script")
             for script in soup(["script", "style", "title", "noscript"]):
                 script.extract()
             text_content = soup.get_text(strip=True)

--- a/fuji_server/helper/metadata_collector_dublincore.py
+++ b/fuji_server/helper/metadata_collector_dublincore.py
@@ -113,11 +113,11 @@ class MetaDataCollectorDublinCore(MetaDataCollector):
                 self.content_type = "text/html"
                 try:
                     metasoup = BeautifulSoup(self.source_metadata, "lxml")
-                    meta_dc_soupresult = metasoup.findAll(
+                    meta_dc_soupresult = metasoup.find_all(
                         "meta", attrs={"name": re.compile(r"(DC|dc|DCTERMS|dcterms)\.([A-Za-z]+)")}
                     )
                     if len(meta_dc_soupresult) <= 0:
-                        meta_dc_soupresult = metasoup.findAll(
+                        meta_dc_soupresult = metasoup.find_all(
                             "meta", attrs={"name": re.compile(r"(" + "|".join(dc_core_base_props) + ")")}
                         )
                     for meta_tag in meta_dc_soupresult:

--- a/fuji_server/helper/metadata_collector_highwire_eprints.py
+++ b/fuji_server/helper/metadata_collector_highwire_eprints.py
@@ -58,7 +58,7 @@ class MetaDataCollectorHighwireEprints(MetaDataCollector):
             self.metadata_format = MetadataFormats.HTML
             self.content_type = "text/html"
             metasoup = BeautifulSoup(self.source_metadata, "lxml")
-            meta_hw_soupresult = metasoup.findAll(
+            meta_hw_soupresult = metasoup.find_all(
                 "meta", attrs={"name": re.compile(r"(eprints\.|citation_)([A-Z_a-z]+)")}
             )
             flipped_hw = Mapper.flip_dict(Mapper.HIGHWIRE_MAPPING.value)


### PR DESCRIPTION
In the test runs there were a lot of warnings, among them a few deprecation warnings from `beautifulsoup`, e.g. 

```
tests/functional/test_evaluation.py::test_evaluation
  /home/runner/work/fuji/fuji/fuji_server/harvester/metadata_harvester.py:679: DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
    script_content = soup.findAll("script")
```

This PR makes replaces findAll with find_all.
