### PR TITLE
feat: bump python version to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - uses: tox-dev/action-pre-commit-uv@246b66536e366bb885f52d61983bf32f7c95e8b1 # v1.0.3
 
   tests:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.13'
         cache: pip
     - run: |
         python -m pip install --upgrade pip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ If you are proposing a feature:
 
 Ready to contribute?
 
-You need Python 3.11+ and [hatch](https://github.com/pypa/hatch). You can install it globally with [pipx](https://github.com/pypa/pipx):
+You need Python 3.13+ and [hatch](https://github.com/pypa/hatch). You can install it globally with [pipx](https://github.com/pypa/pipx):
 
 ```console
 $ pipx install hatch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.5
-# at the moment only Python 3.11 is supported
-FROM python:3.11-slim
+# Note: At the moment only Python 3.13 is supported
+FROM python:3.13-slim
 
 WORKDIR /usr/src/app
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Thanks to [Heinz-Alexander Fuetterer](https://github.com/afuetterer) for his con
 | __CI__ | [![CI](https://github.com/pangaea-data-publisher/fuji/actions/workflows/ci.yml/badge.svg)](https://github.com/pangaea-data-publisher/fuji/actions/workflows/ci.yml) [![Coverage](https://coveralls.io/repos/github/pangaea-data-publisher/fuji/badge.svg?branch=master)](https://coveralls.io/github/pangaea-data-publisher/fuji?branch=master) |
 | :--- | :--- |
 | __CD__ | [![Publish Docker image](https://github.com/pangaea-data-publisher/fuji/actions/workflows/publish-docker.yml/badge.svg)](https://github.com/pangaea-data-publisher/fuji/actions/workflows/publish-docker.yml) |
-| __Package__ | [![Python Version](https://img.shields.io/badge/python-3.11-blue)](https://www.python.org/) |
+| __Package__ | [![Python Version](https://img.shields.io/badge/python-3.13-blue)](https://www.python.org/) |
 | __Meta__    | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11084909.svg)](https://doi.org/10.5281/zenodo.11084909) [![GitHub License](https://img.shields.io/github/license/pangaea-data-publisher/fuji.svg)](https://github.com/pangaea-data-publisher/fuji/blob/master/LICENSE) [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) |
 
 ## Overview

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Information Analysis"
 ]
 dependencies = [
@@ -61,7 +61,7 @@ keywords = [
 license = "MIT"
 name = "fuji"
 readme = "README.md"
-requires-python = "~=3.11"  # at the moment only Python 3.11 is supported
+requires-python = "~=3.13"  # at the moment only Python 3.13 is supported
 version = "3.5.1"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

This PR bumps the Python version used for fuji to 3.13.

## Motivation and context

Python 3.13 is out for over a year.

## How has this been tested?

Tests are passing In CI.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
